### PR TITLE
Apply 1.1 changes made on Core Trac to GitHub repository

### DIFF
--- a/classes/class-twentynineteen-walker-comment.php
+++ b/classes/class-twentynineteen-walker-comment.php
@@ -46,7 +46,7 @@ class TwentyNineteen_Walker_Comment extends Walker_Comment {
 								echo $avatar;
 							}
 						}
-
+						
 						/*
 						 * Using the `check` icon instead of `check_circle`, since we can't add a
 						 * fill color to the inner check shape when in circle form.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: the WordPress team
 Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
 Requires at least: 4.9.6
-Tested up to: 5.0
-Stable tag: 1.0
+Tested up to: WordPress 5.0
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,8 +14,15 @@ Our 2019 default theme is designed to show off the power of the block editor. It
 
 == Changelog ==
 
+= 1.1 =
+* Released: December 19, 2018
+
+https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.1
+
 = 1.0 =
-* Initial Release
+* Released: December 6, 2018
+
+Initial release
 
 == Resources ==
 * normalize.css, © 2012-2018 Nicolas Gallagher and Jonathan Neal, MIT

--- a/style-editor.css
+++ b/style-editor.css
@@ -531,39 +531,14 @@ figcaption,
   max-width: 50%;
 }
 
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote,
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote,
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote {
+.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color),
+.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote:not(.is-style-solid-color) {
   padding: 0;
 }
 
-.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color blockquote,
-.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color blockquote {
-  width: 100%;
-  max-width: 100%;
-  padding: calc(1.375 * 1rem);
-}
-
-@media only screen and (min-width: 768px) {
-  .wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color blockquote,
-  .wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color blockquote {
-    padding: calc(2.75 * 1rem) calc(2.75 * 1rem) calc(3.125 * 1rem);
-  }
-}
-
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote {
-  margin: 1rem 0;
-}
-
-.wp-block[data-type="core/pullquote"][data-align="left"] blockquote p:first-child,
-.wp-block[data-type="core/pullquote"][data-align="right"] blockquote p:first-child {
-  margin-top: 0;
+.wp-block[data-type="core/pullquote"][data-align="left"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color,
+.wp-block[data-type="core/pullquote"][data-align="right"] .editor-block-list__block-edit .wp-block-pullquote.is-style-solid-color {
+  padding: 1em;
 }
 
 .wp-block[data-type="core/pullquote"][data-align="left"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -500,34 +500,12 @@ figcaption,
 		width: calc(4 * (100vw / 12));
 		max-width: 50%;
 
-		.wp-block-pullquote {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
-
-		.wp-block-pullquote {
+		.wp-block-pullquote:not(.is-style-solid-color) {
 			padding: 0;
 		}
 
 		.wp-block-pullquote.is-style-solid-color {
-
-			blockquote {
-				width: 100%;
-				max-width: 100%;
-				padding: calc(1.375 * #{$size__spacing-unit});
-
-				@include media(tablet) {
-					padding: calc(2.75 * #{$size__spacing-unit}) calc(2.75 * #{$size__spacing-unit}) calc(3.125 * #{$size__spacing-unit});
-				}
-			}
-		}
-	}
-
-	blockquote {
-		margin: $size__spacing-unit 0;
-
-		p:first-child {
-			margin-top: 0;
+			padding: 1em;
 		}
 	}
 
@@ -627,14 +605,9 @@ figcaption,
 
 /* Remove duplicate rule-line when a separator
  * is followed by an H1, or H2 */
-.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] {
-
-	h1,
-	h2 {
-		&:before {
-			display: none;
-		}
-	}
+.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h1:before,
+.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h2:before {
+	display: none;
 }
 
 /** === Latest Posts, Archives, Categories === */

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A new Gutenberg-ready theme.
 Requires at least: WordPress 4.9.6
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen

--- a/style.scss
+++ b/style.scss
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: A new Gutenberg-ready theme.
 Requires at least: WordPress 4.9.6
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: twentynineteen


### PR DESCRIPTION
Apparently, the WordPress GitHub repository will be archived soon.. So let's apply it here.